### PR TITLE
Refactor tor-docker-compose for multi-arch and project isolation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
-version: "2.4"
+version: "3.8"
 
 services:
-  # tor:
+  # tor2:
   #   image: wizardrysteamworks/tor-snowflake:latest
-  #   container_name: tor
+  #   container_name: tor2
   #   restart: always
   #   # Expose only to host's loopback
   #   ports:
@@ -13,14 +13,14 @@ services:
   #     - ./tor/etc:/run/tor/config:Z
   #     - ./tor/data:/run/tor/data:Z
 
-  multitor:
+  multitor2:
     # Note: rebuild this frequently as newer snowflake clients offer more stealth
     build: ./multitor
-    container_name: multitor
+    container_name: multitor2
     ports:
-      - "16378:16378" # Custom Load-balancer
-      - "16379:16379" # Maps host port 16379 to container port 16379 (HAProxy)
-      - "16380:16380" # HAProxy Stats
+      - "26378:16378" # Custom Load-balancer
+      - "26379:16379" # Maps host port 16379 to container port 16379 (HAProxy)
+      - "26380:16380" # HAProxy Stats
     volumes:
       - ./multitor/templates:/usr/src/app/templates:Z # Maps custom templates from host to container
     environment:
@@ -44,37 +44,37 @@ services:
   #     #  # Lower Priority Than Default Processes (Default is 1024)
   #     #    cpu_shares: 512
   
-  # dpyproxy:
+  # dpyproxy2:
   #   build: ./dpyproxy
   #   ports:
   #     - "4433:4433" # Proxy-Server
   #   restart: always
   #   command: ["--frag_size", "20", "--debug", "--port", "4433", "--host", "0.0.0.0"]
   
-  psiphon:
+  psiphon2:
     image: swarupsengupta2007/psiphon:latest
-    container_name: psiphon
+    container_name: psiphon2
     depends_on:
-      - multitor
+      - multitor2
     environment:
       - PUID=1000
       - PGID=1000
     volumes:
       - ./psiphon:/config:Z
     ports:
-      - "1080:1080"   # Psiphon SOCKS
-      - "8080:8080"   # Psiphon HTTP
+      - "2080:1080"   # Psiphon SOCKS
+      - "9080:8080"   # Psiphon HTTP
     restart: always
 
   # Note 1: Doesn't Work As Tor Socks5 Doesn't Support UDP Protocol.
   # Note 2: But It May Work With Psiphon
-  # warp:
+  # warp2:
   #   build: ./warp
-  #   container_name: warp
+  #   container_name: warp2
   #   depends_on:
-  #     - psiphon
+  #     - psiphon2
   #   ports:
-  #     - "8086:8086"   # WARP SOCKS5 Proxy
+  #     - "9086:8086"   # WARP SOCKS5 Proxy
   #   cap_add:
   #     - NET_ADMIN     # Required to create TUN device and manage routing
   #   devices:

--- a/multitor/Dockerfile
+++ b/multitor/Dockerfile
@@ -1,6 +1,8 @@
 # Use alpine as the base image
 FROM alpine:latest
 
+ARG TARGETARCH
+
 # Environment variables for package versions or configurations
 ENV BUILD_PACKAGES="build-base openssl-dev ca-certificates wget curl git vim" \
     PACKAGES="tor lyrebird webtunnel meek snowflake sudo bash haproxy privoxy procps" \
@@ -20,8 +22,14 @@ RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/main/" >> /etc/apk/reposito
 #     chmod +x /usr/bin/snowflake-client
 
 # Build and install Conjure Pluggable Transport
-RUN wget -qO /usr/bin/conjure-client \
-    "https://github.com/PacketCipher/tor-conjure/releases/download/v0.1.0/conjure-client-linux-amd64-musl" && \
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        wget -qO /usr/bin/conjure-client "https://github.com/PacketCipher/tor-conjure/releases/download/v0.1.0/conjure-client-linux-amd64-musl"; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        wget -qO /usr/bin/conjure-client "https://github.com/NullRoute-Lab/tor-conjure/releases/download/v0.1.0-arm1/conjure-client-linux-arm64-musl"; \
+    else \
+        echo "Unsupported architecture: $TARGETARCH"; \
+        exit 1; \
+    fi && \
     chmod +x /usr/bin/conjure-client
 
 # Set up application directory

--- a/psiphon/psiphon.config
+++ b/psiphon/psiphon.config
@@ -3,7 +3,7 @@
   "ListenInterface": "any",
   "LocalHttpProxyPort": 8080,
   "LocalSocksProxyPort": 1080,
-  "UpstreamProxyUrl": "socks5://multitor:16378",
+  "UpstreamProxyUrl": "socks5://multitor2:16378",
   "UseIndistinguishableTLS": true,
   "EgressRegion":"US",
   "PropagationChannelId":"FFFFFFFFFFFFFFFF",

--- a/warp/Dockerfile
+++ b/warp/Dockerfile
@@ -1,6 +1,8 @@
 # Use a lightweight Debian image as the base
 FROM debian:bookworm-slim
 
+ARG TARGETARCH
+
 # Install necessary dependencies for warp-plus and tun2socks
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
@@ -17,13 +19,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # Download and install tun2socks
-RUN wget https://github.com/xjasonlyu/tun2socks/releases/download/v2.5.2/tun2socks-linux-amd64.zip \
-    && unzip tun2socks-linux-amd64.zip \
-    && mv tun2socks-linux-amd64 /usr/local/bin/tun2socks \
-    && rm tun2socks-linux-amd64.zip
+RUN wget https://github.com/xjasonlyu/tun2socks/releases/download/v2.5.2/tun2socks-linux-${TARGETARCH}.zip \
+    && unzip tun2socks-linux-${TARGETARCH}.zip \
+    && mv tun2socks-linux-${TARGETARCH} /usr/local/bin/tun2socks \
+    && rm tun2socks-linux-${TARGETARCH}.zip
 
 # Download and extract the warp-plus binary
-RUN curl -L -o warp-plus.zip https://github.com/bepass-org/warp-plus/releases/download/v1.2.6/warp-plus_linux-amd64.zip \
+RUN curl -L -o warp-plus.zip https://github.com/bepass-org/warp-plus/releases/download/v1.2.6/warp-plus_linux-${TARGETARCH}.zip \
     && unzip warp-plus.zip \
     && rm warp-plus.zip
 


### PR DESCRIPTION
Refactor tor-docker-compose for multi-arch and project isolation

- Implemented multi-arch support (`amd64`/`arm64`) using `ARG TARGETARCH`
  in `warp/Dockerfile` and `multitor/Dockerfile`.
- Added conditional script for fetching correct `conjure-client` binary based on architecture.
- Upgraded docker-compose.yml to version 3.8.
- Appended `2` to all services and `container_name`s to prevent clashes with v1 instances.
- Shifted all host-mapped ports to a new range.
- Updated `UpstreamProxyUrl` in `psiphon/psiphon.config` to use `multitor2`.

---
*PR created automatically by Jules for task [9694056386022089992](https://jules.google.com/task/9694056386022089992) started by @AmirParsaRabiei*