### PR TITLE
feat: implement local automation and weekly cloud cache seeding

### DIFF
--- a/.github/workflows/weekly-seed.yml
+++ b/.github/workflows/weekly-seed.yml
@@ -1,0 +1,55 @@
+name: Weekly Cloud Cache Seeding
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Every Sunday at midnight
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Start stack
+        run: |
+          docker compose up -d multitor2 psiphon2
+
+      - name: Let Psiphon run to fetch global node directory
+        run: |
+          echo "Waiting for 90 seconds..."
+          sleep 90
+
+      - name: Gracefully stop containers
+        run: |
+          # Stop containers to flush data and release file locks
+          docker compose stop
+
+      - name: Seed files
+        run: |
+          mkdir -p psiphon-seed
+          cp ./psiphon/remote_server_list ./psiphon-seed/ || true
+          cp ./psiphon/psiphon.boltdb ./psiphon-seed/ || true
+
+      - name: Clean up environment
+        run: |
+          docker compose down -v
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add psiphon-seed/
+          # Only commit if there are changes
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "chore: Weekly Cloud Cache Seeding [skip ci]"
+            git push origin HEAD
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# tor-docker-compose
+
+This repository provides a powerful, privacy-preserving stack combining Tor, multitor, and Psiphon using Docker Compose. It features a Local Automation Strategy and Weekly Cloud Cache Seeding.
+
+## Architecture
+
+*   **multitor2**: A custom load-balancer that manages multiple Tor instances for enhanced performance and reliability.
+*   **psiphon2**: A Psiphon instance configured to use `multitor2` as its upstream proxy, circumventing network restrictions.
+
+## Local Automation Strategy
+
+To keep your Tor relays fresh and maintain optimal performance, you can use the `run_local_scan.sh` script. This script automates scanning for relays, updating the Tor configuration templates, and restarting `multitor2` gracefully so it picks up the freshly scanned relays.
+
+### Setting up a Daily Cronjob
+
+On a machine like a Raspberry Pi, you can automate this process by setting up a cronjob.
+
+1.  Make sure the script is executable:
+    ```bash
+    chmod +x run_local_scan.sh
+    ```
+
+2.  Open your crontab:
+    ```bash
+    crontab -e
+    ```
+
+3.  Add the following line to run the script automatically every day at 03:30 AM (e.g., Iran Time):
+    ```cron
+    30 3 * * * cd /path/to/your/tor-docker-compose && ./run_local_scan.sh >> /var/log/run_local_scan.log 2>&1
+    ```
+    *(Replace `/path/to/your/tor-docker-compose` with the actual path to your cloned repository.)*
+
+## Weekly Cloud Cache Seeding
+
+To ensure that new devices can start instantly without encountering the `EstablishTunnelTimeout` error in Psiphon, a GitHub Actions workflow is set up to run every Sunday at midnight (`0 0 * * 0`).
+
+The workflow spins up the stack, lets Psiphon fetch its global node directory, copies the critical cache files (`remote_server_list` and `psiphon.boltdb`) into the `psiphon-seed/` directory, and automatically commits these changes back to the repository.
+
+### GitHub Actions Permissions
+
+For the automated workflow to commit the seeded cache back to your repository, you need to enable specific permissions in your GitHub repository settings:
+
+1.  Go to your repository on GitHub.
+2.  Click on **Settings** > **Actions** > **General**.
+3.  Scroll down to **Workflow permissions**.
+4.  Select **Read and write permissions**.
+5.  Check the box for **Allow GitHub Actions to create and approve pull requests**.
+6.  Click **Save**.
+
+### Zero-Touch New Device Boot
+
+Thanks to the automated cache seeding, deploying this stack on a new device is completely hands-off.
+
+When you clone this repository and run `docker compose up -d` for the first time, the `psiphon2` container utilizes a smart `entrypoint`. It detects the "cold start" (absence of the existing config) and instantly injects the pre-seeded cache from the `psiphon-seed/` directory into its configuration folder. This allows Psiphon to bypass the initial long bootstrapping process and connect immediately.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,16 @@ services:
       - PGID=1000
     volumes:
       - ./psiphon:/config:Z
+      - ./psiphon-seed:/seed:ro
+    entrypoint: >
+      /bin/sh -c '
+      if [ ! -f /config/remote_server_list ] && [ -d /seed ]; then
+          echo "Cold start detected. Injecting emergency backup cache..."
+          cp -r /seed/* /config/ 2>/dev/null || true
+          chown -R 1000:1000 /config/
+      fi;
+      exec /init
+      '
     ports:
       - "2080:1080"   # Psiphon SOCKS
       - "9080:8080"   # Psiphon HTTP

--- a/run_local_scan.sh
+++ b/run_local_scan.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Starting local relay scan..."
+cd utils/tor-relay-scanner/
+bash start.sh
+
+echo "Updating templates..."
+cd ../../
+bash update_templates.sh
+
+echo "Restarting multitor2 to apply fresh relays..."
+docker restart multitor2
+
+echo "Done!"


### PR DESCRIPTION
Implemented the Local Automation Strategy and Weekly Cloud Cache Seeding features as requested. 
Includes:
- `.github/workflows/weekly-seed.yml` for weekly automatic cache seeding with safe container stopping to prevent database corruption.
- `run_local_scan.sh` to facilitate local cronjob updates to Tor relays.
- `README.md` with full documentation on cronjob setup, GitHub Actions permissions, and zero-touch new device booting.
- Modifications to `docker-compose.yml` to use a volume mount and a custom entrypoint script for injecting the `psiphon-seed` data into the container on first boot.

---
*PR created automatically by Jules for task [1361558143257907894](https://jules.google.com/task/1361558143257907894) started by @AmirParsaRabiei*