### PR TITLE
fix: fix nested psiphon path in seeding

### DIFF
--- a/.github/workflows/weekly-seed.yml
+++ b/.github/workflows/weekly-seed.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Let Psiphon run to fetch global node directory
         run: |
-          echo "Waiting for 90 seconds..."
-          sleep 90
+          echo "Waiting for 150 seconds..."
+          sleep 150
 
       - name: Gracefully stop containers
         run: |
@@ -32,8 +32,7 @@ jobs:
       - name: Seed files
         run: |
           mkdir -p psiphon-seed
-          cp ./psiphon/remote_server_list ./psiphon-seed/ || true
-          cp ./psiphon/psiphon.boltdb ./psiphon-seed/ || true
+          sudo cp -r ./psiphon/ca.psiphon.PsiphonTunnel.tunnel-core ./psiphon-seed/ 2>/dev/null || true
 
       - name: Clean up environment
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - ./psiphon-seed:/seed:ro
     entrypoint: >
       /bin/sh -c '
-      if [ ! -f /config/remote_server_list ] && [ -d /seed ]; then
+      if [ ! -f /config/ca.psiphon.PsiphonTunnel.tunnel-core/remote_server_list ] && [ -d /seed/ca.psiphon.PsiphonTunnel.tunnel-core ]; then
           echo "Cold start detected. Injecting emergency backup cache..."
           cp -r /seed/* /config/ 2>/dev/null || true
           chown -R 1000:1000 /config/


### PR DESCRIPTION
- Updated `docker-compose.yml` entrypoint check to look inside `ca.psiphon.PsiphonTunnel.tunnel-core/`.
- Updated `weekly-seed.yml` workflow to sleep for 150 seconds and use `sudo cp -r` for the `ca.psiphon.PsiphonTunnel.tunnel-core/` path.