### PR TITLE
fix: resolve weekly seed Action permission & resource issues

### DIFF
--- a/.github/workflows/weekly-seed.yml
+++ b/.github/workflows/weekly-seed.yml
@@ -21,8 +21,12 @@ jobs:
 
       - name: Let Psiphon run to fetch global node directory
         run: |
-          echo "Waiting for 150 seconds..."
-          sleep 150
+          echo "Waiting for 240 seconds..."
+          sleep 240
+          echo "=== MULTITOR LOGS ==="
+          docker logs multitor2 || true
+          echo "=== PSIPHON LOGS ==="
+          docker logs psiphon2 || true
 
       - name: Gracefully stop containers
         run: |
@@ -33,6 +37,7 @@ jobs:
         run: |
           mkdir -p psiphon-seed
           sudo cp -r ./psiphon/ca.psiphon.PsiphonTunnel.tunnel-core ./psiphon-seed/ 2>/dev/null || true
+          sudo chown -R runner:docker ./psiphon-seed
 
       - name: Clean up environment
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     environment:
       ## More Instances = More Untracability + More Chance Of Good Circuits & Less Top_N_Proxies = Better Ping & Balanced Top_N_Proxies = More Speed Due To Good Circuits Concurrency
       ## For Time-Sensitive Stuff Such As Gaming And Realtime Messaging Better To Use Ping Check & For Speed-Sensitive Stuff Better To Use Download Check (TODO: Two Separate Socks5 Server)
-      - TOR_INSTANCES=44 # Default number of Tor instances, can be overridden in .env file or by CLI, 2x number of templates for default is preferred, 4x number of templates for high-restricted networks is preferred, for custom cases such as snowflake only or snowflake + relay scanner only you would assign high quantity for maximum chance of connection, regardless of number of instances the maximum bootstrap time is 30 minutes.
+      - TOR_INSTANCES=16 # Default number of Tor instances, can be overridden in .env file or by CLI, 2x number of templates for default is preferred, 4x number of templates for high-restricted networks is preferred, for custom cases such as snowflake only or snowflake + relay scanner only you would assign high quantity for maximum chance of connection, regardless of number of instances the maximum bootstrap time is 30 minutes.
       - PROXY_MODE=custom_lb # Proxy Mode Options: socks, custom_lb
       - LB_Top_N_Proxies=4 # number of proxies to roundrobin for custom_lb, for networks with high interrupts and dpi the higher number is better but it may affect speed inversely
       # - LB_Algorithm=sequential # sequential algorithm will retry each request sequentially sorted by check mode


### PR DESCRIPTION
Fixes the GitHub Action for the weekly seed:
- Resolves file permission denials during `git commit` by adding `sudo chown -R runner:docker`.
- Prevents resource exhaustion on standard 2-core GitHub runners by lowering `TOR_INSTANCES` to 16.
- Increases the wait time to 240 seconds for optimal bootstrap completion.
- Adds container logs for debugging.

---
*PR created automatically by Jules for task [10476853654678828065](https://jules.google.com/task/10476853654678828065) started by @AmirParsaRabiei*