### PR TITLE
Fix psiphon2 entrypoint CRLF issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,15 +62,7 @@ services:
     volumes:
       - ./psiphon:/config:Z
       - ./psiphon-seed:/seed:ro
-    entrypoint: |
-      /bin/sh -c '
-      if [ ! -f /config/ca.psiphon.PsiphonTunnel.tunnel-core/remote_server_list ] && [ -d /seed/ca.psiphon.PsiphonTunnel.tunnel-core ]; then
-          echo "Cold start detected. Injecting emergency backup cache..."
-          cp -r /seed/* /config/ 2>/dev/null || true
-          chown -R 1000:1000 /config/
-      fi;
-      exec /init
-      '
+    entrypoint: ["/bin/sh", "-c", "if [ ! -f /config/ca.psiphon.PsiphonTunnel.tunnel-core/remote_server_list ] && [ -d /seed/ca.psiphon.PsiphonTunnel.tunnel-core ]; then echo 'Cold start detected. Injecting cache...'; cp -r /seed/* /config/ 2>/dev/null || true; chown -R 1000:1000 /config/ 2>/dev/null || true; fi; exec /init"]
     ports:
       - "2080:1080"   # Psiphon SOCKS
       - "9080:8080"   # Psiphon HTTP


### PR DESCRIPTION
Fix psiphon2 entrypoint CRLF issue in docker-compose.yml by changing the entrypoint to a JSON array.

---
*PR created automatically by Jules for task [12217556767505466645](https://jules.google.com/task/12217556767505466645) started by @AmirParsaRabiei*