### PR TITLE
Refactor psiphon2 to use an Init Container for seeding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,18 +51,28 @@ services:
   #   restart: always
   #   command: ["--frag_size", "20", "--debug", "--port", "4433", "--host", "0.0.0.0"]
   
+  psiphon-seeder:
+    image: alpine:latest
+    container_name: psiphon_seeder
+    volumes:
+      - ./psiphon:/config:Z
+      - ./psiphon-seed:/seed:ro
+    command: ["/bin/sh", "-c", "if [ ! -f /config/ca.psiphon.PsiphonTunnel.tunnel-core/remote_server_list ] && [ -d /seed/ca.psiphon.PsiphonTunnel.tunnel-core ]; then echo 'Cold start detected. Injecting cache...'; cp -r /seed/* /config/ 2>/dev/null || true; chown -R 1000:1000 /config 2>/dev/null || true; fi"]
+    restart: "no"
+
   psiphon2:
     image: swarupsengupta2007/psiphon:latest
     container_name: psiphon2
     depends_on:
-      - multitor2
+      multitor2:
+        condition: service_started
+      psiphon-seeder:
+        condition: service_completed_successfully
     environment:
       - PUID=1000
       - PGID=1000
     volumes:
       - ./psiphon:/config:Z
-      - ./psiphon-seed:/seed:ro
-    entrypoint: ["/bin/sh", "-c", "if [ ! -f /config/ca.psiphon.PsiphonTunnel.tunnel-core/remote_server_list ] && [ -d /seed/ca.psiphon.PsiphonTunnel.tunnel-core ]; then echo 'Cold start detected. Injecting cache...'; cp -r /seed/* /config/ 2>/dev/null || true; chown -R 1000:1000 /config/ 2>/dev/null || true; fi; exec /init"]
     ports:
       - "2080:1080"   # Psiphon SOCKS
       - "9080:8080"   # Psiphon HTTP


### PR DESCRIPTION
The `swarupsengupta2007/psiphon` image is built on `s6-overlay`. Overriding the `entrypoint` directly was destroying the internal boot sequence, causing instantaneous container crashes.

This change implements the "Init Container" pattern:
- A new `psiphon-seeder` service (using `alpine:latest` and running as default root) injects the needed cache and adjusts permissions if a cold start is detected.
- `psiphon-seeder` utilizes a strictly formatted JSON array for its command to avoid OS line-ending issues and has `restart: "no"` so it only runs once.
- `psiphon2` is reverted to its pure state (no `entrypoint` or seed volume) and configured via `depends_on` to start only after the seeder finishes successfully and `multitor2` starts.

---
*PR created automatically by Jules for task [2606934376383956399](https://jules.google.com/task/2606934376383956399) started by @AmirParsaRabiei*