### PR TITLE
ci: increase wait time for Psiphon seed caching to 420 seconds

### DIFF
--- a/.github/workflows/weekly-seed.yml
+++ b/.github/workflows/weekly-seed.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Let Psiphon run to fetch global node directory
         run: |
-          echo "Waiting for 240 seconds..."
-          sleep 240
+          echo "Waiting for 420 seconds..."
+          sleep 420
           echo "=== MULTITOR LOGS ==="
           docker logs multitor2 || true
           echo "=== PSIPHON LOGS ==="


### PR DESCRIPTION
- Updates `.github/workflows/weekly-seed.yml` to wait for 420 seconds (7 minutes) instead of 240 seconds.
- Gives Tor instances enough time to fully bootstrap, build circuits, and allow Psiphon to finish fetching the global server list cache before termination.