### PR TITLE
Optimize GitHub Actions weekly seed by allowing Psiphon direct connection

### DIFF
--- a/.github/workflows/weekly-seed.yml
+++ b/.github/workflows/weekly-seed.yml
@@ -15,26 +15,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Patch Compose for GitHub Runner
+      - name: Patch configs for Direct Cloud Seeding
         run: |
-          # Dynamically patch the compose file to 2 instances ONLY in the ephemeral runner.
-          # This bypasses the hardcoded limit without polluting the repository code.
+          # Scale down Tor to avoid CPU starvation
           sed -i 's/TOR_INSTANCES=16/TOR_INSTANCES=2/g' docker-compose.yml
+          # Remove upstream proxy from Psiphon config ONLY in the runner.
+          # GitHub Actions has open internet, so Psiphon can seed instantly!
+          sed -i '/UpstreamProxyUrl/d' psiphon/psiphon.config
 
-      - name: Start MultiTor and Warm Up
+      - name: Start Psiphon and Fetch Cache Directly
         run: |
-          docker compose up -d multitor2
-          echo "Waiting 180 seconds for Tor circuits to build and warm up..."
-          sleep 180
-          echo "=== MULTITOR LOGS ==="
-          docker logs multitor2 || true
-
-      - name: Start Psiphon and Fetch Cache
-        run: |
-          # Start Psiphon. The --no-recreate flag strictly forbids Docker from destroying our warmed-up Tor!
-          docker compose up -d --no-recreate psiphon2
-          echo "Waiting 180 seconds for Psiphon to download the cache..."
-          sleep 180
+          # Since Psiphon now connects directly, we don't need to pre-warm Tor!
+          docker compose up -d psiphon2
+          echo "Waiting 90 seconds for Psiphon to download the cache via direct connection..."
+          sleep 90
           echo "=== PSIPHON LOGS ==="
           docker logs psiphon2 || true
 
@@ -51,8 +45,9 @@ jobs:
 
       - name: Clean up environment
         run: |
-          # Restore the original compose file so it doesn't get committed
+          # Restore the original files so they don't get committed
           git checkout docker-compose.yml
+          git checkout psiphon/psiphon.config
           docker compose down -v
 
       - name: Commit and push changes


### PR DESCRIPTION
This submission updates `.github/workflows/weekly-seed.yml` so that Psiphon directly accesses the internet to fetch its initial cache in the GitHub Actions runner. This is done by dynamically removing `UpstreamProxyUrl` from the config during the run.

By allowing Psiphon to connect directly, the cache fetching is drastically sped up, mitigating delays from Tor/Snowflake on Azure IP ranges. The commit also condenses the startup commands and ensures the `psiphon.config` modification is properly cleaned up before committing the new cache files.

---
*PR created automatically by Jules for task [4247420788221089864](https://jules.google.com/task/4247420788221089864) started by @AmirParsaRabiei*