### PR TITLE
Fix Git permissions during GitHub Actions cleanup step

### DIFF
--- a/.github/workflows/weekly-seed.yml
+++ b/.github/workflows/weekly-seed.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Clean up environment
         run: |
+          # Fix permissions so git can modify the files
+          sudo chown -R runner:docker ./psiphon docker-compose.yml
           # Restore the original files so they don't get committed
           git checkout docker-compose.yml
           git checkout psiphon/psiphon.config


### PR DESCRIPTION
Docker containers running as UID 1000 changed the ownership of the mounted `./psiphon` directory, which prevented the GitHub runner from using `git checkout` to restore `psiphon/psiphon.config`. This commit adds a `sudo chown` command prior to the checkout to reclaim file ownership and prevent permission denied errors.