### PR TITLE
docs: Update README with Psiphon regions and modern automation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,29 +7,72 @@ This repository provides a powerful, privacy-preserving stack combining Tor, mul
 *   **multitor2**: A custom load-balancer that manages multiple Tor instances for enhanced performance and reliability.
 *   **psiphon2**: A Psiphon instance configured to use `multitor2` as its upstream proxy, circumventing network restrictions.
 
-## Local Automation Strategy
+## Changing Psiphon Region (Location)
 
-To keep your Tor relays fresh and maintain optimal performance, you can use the `run_local_scan.sh` script. This script automates scanning for relays, updating the Tor configuration templates, and restarting `multitor2` gracefully so it picks up the freshly scanned relays.
+- Users can easily change their exit IP location by editing `psiphon/psiphon.config` and modifying the `"EgressRegion"` value.
+- Because the pre-seeded cache (`remote_server_list`) is globally cached by our GitHub Actions, changing the region works instantly without needing a new cache.
+- Highly recommended 2-letter ISO country codes: `US` (USA), `GB` (UK), `DE` (Germany), `NL` (Netherlands), `FR` (France), `CA` (Canada), `SG` (Singapore), and `JP` (Japan).
+- Setting `"EgressRegion": ""` (an empty string) allows Psiphon to auto-select the fastest available region based on ping.
+- To apply the changes, simply run: `docker restart psiphon2`
 
-### Setting up a Daily Cronjob
+## Keeping Relays Fresh (Automation)
 
-On a machine like a Raspberry Pi, you can automate this process by setting up a cronjob.
+To keep your Tor relays fresh and maintain optimal performance, the `run_local_scan.sh` script automatically scans for unblocked relays based on your specific ISP and restarts MultiTor. This script automates scanning for relays, updating the Tor configuration templates, and restarting `multitor2` gracefully so it picks up the freshly scanned relays. Since users run different Linux distros, you can choose from the two automation options below.
 
-1.  Make sure the script is executable:
-    ```bash
-    chmod +x run_local_scan.sh
-    ```
+### Option A: Crontab (For Raspberry Pi / Debian / Ubuntu)
 
-2.  Open your crontab:
+This is the simplest method for traditional distros like Raspberry Pi OS, Debian, or Ubuntu.
+
+1.  Open your crontab:
     ```bash
     crontab -e
     ```
 
-3.  Add the following line to run the script automatically every day at 03:30 AM (e.g., Iran Time):
-    ```cron
-    30 3 * * * cd /path/to/your/tor-docker-compose && ./run_local_scan.sh >> /var/log/run_local_scan.log 2>&1
+2.  Add the following line to run the script automatically every day at 03:30 AM. This includes simple log rotation to prevent infinite log bloat by keeping only the last 500 lines:
+    ```bash
+    30 3 * * * cd /path/to/your/tor-docker-compose && bash run_local_scan.sh >> local_scan.log 2>&1 && tail -n 500 local_scan.log > temp_scan.log && mv temp_scan.log local_scan.log
     ```
     *(Replace `/path/to/your/tor-docker-compose` with the actual path to your cloned repository.)*
+
+### Option B: Systemd User Timers (For Bluefin / Fedora / Immutable Distros)
+
+Modern immutable distributions (like Bluefin or Fedora Silverblue) typically use systemd instead of cron.
+
+**Step 1:** Create the systemd service file at `~/.config/systemd/user/tor-scan.service`:
+```ini
+[Unit]
+Description=Run Tor Local Relay Scanner
+After=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/tor-docker-compose
+ExecStart=/usr/bin/bash run_local_scan.sh
+```
+
+**Step 2:** Create the timer file at `~/.config/systemd/user/tor-scan.timer`:
+```ini
+[Unit]
+Description=Run Tor Local Scan Daily at 03:30
+
+[Timer]
+OnCalendar=*-*-* 03:30:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+**Step 3:** Reload the systemd daemon and enable the timer (no sudo needed):
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now tor-scan.timer
+```
+
+**Pro-Tip:** Systemd's `journald` natively handles log rotation and disk space management, so you don't need to worry about log bloat. You can safely check your recent logs anytime with:
+```bash
+journalctl --user -u tor-scan.service -e
+```
 
 ## Weekly Cloud Cache Seeding
 


### PR DESCRIPTION
Update README.md to reflect stable rootful Docker deployment and modernize documentation for enterprise standards. Added a new section for easily changing the Psiphon region and completely rewrote the automation section to include setup instructions for both traditional distributions (using cron with log rotation) and modern immutable distributions (using systemd user timers).

---
*PR created automatically by Jules for task [10645974385099223796](https://jules.google.com/task/10645974385099223796) started by @AmirParsaRabiei*